### PR TITLE
Add backend release candidate APIs and implement role-based access control

### DIFF
--- a/docs/architecture/permissions.md
+++ b/docs/architecture/permissions.md
@@ -1,0 +1,57 @@
+# API Permission Matrix
+
+This document defines the MVP product-role authorization matrix for the API-first iteration.
+
+## Source of truth
+
+- Product role is stored in `apps.users.models.UserProfile.role`.
+- Supported product roles: `student`, `customer`, `cpprp`.
+- `Django staff` keeps an administrative override for the endpoints listed below.
+
+## Role matrix
+
+| API surface | Student | Customer | CPPRP | Staff |
+| --- | --- | --- | --- | --- |
+| `GET /api/v1/projects/`, `GET /api/v1/projects/{id}/` | Catalog only; own private drafts also visible when authenticated | Catalog + own private drafts | Catalog + own private drafts if any | Full visibility through existing staff behavior |
+| `POST /api/v1/projects/` | Denied | Allowed | Denied | Allowed |
+| `PATCH/PUT/DELETE /api/v1/projects/{id}/` | Denied | Allowed for owned projects only | Denied | Allowed |
+| `POST /api/v1/projects/{id}/actions/submit/` | Denied | Allowed for owned projects only | Denied | Allowed |
+| `POST /api/v1/projects/{id}/actions/moderate/` | Denied | Denied | Allowed | Allowed |
+| `GET/POST /api/v1/applications/` | Allowed for own applications only | Denied | Denied | Allowed |
+| `GET/PATCH/DELETE /api/v1/applications/{id}/` | Allowed for own applications only | Denied | Denied | Allowed |
+| `POST /api/v1/applications/{id}/actions/review/` | Denied | Allowed for applications of owned projects only | Denied | Allowed |
+| `GET /api/v1/account/student/overview/` | Allowed | Denied | Denied | Allowed |
+| `GET /api/v1/account/customer/projects/`, `GET /api/v1/account/customer/applications/` | Denied | Allowed | Denied | Allowed |
+| `GET /api/v1/account/cpprp/*` moderation/export/configuration endpoints | Denied | Denied | Allowed | Allowed |
+| `GET/POST /api/v1/imports/epp/` | Denied | Denied | Allowed | Allowed |
+| `POST /api/v1/recs/reindex/` | Denied | Denied | Allowed | Allowed |
+
+## Implementation notes
+
+- Endpoint-level enforcement lives in `apps.account.permissions` through reusable DRF permission classes:
+  - `IsStudentOrStaff`
+  - `IsCustomerOrStaff`
+  - `IsCpprpOrStaff`
+- Domain-level transition guards keep the same matrix if business logic is called outside the route layer:
+  - `apps.projects.transitions.submit_project_for_moderation`
+  - `apps.applications.transitions.review_application`
+- Critical CPPRP/staff-only permission denials are logged from `apps.account.permissions`.
+
+## Affected endpoints and tests
+
+- Project permissions and transitions:
+  - `src/web/apps/projects/views.py`
+  - `src/web/apps/projects/transitions.py`
+  - `src/web/apps/projects/tests.py`
+  - `src/web/apps/projects/tests_transitions.py`
+- Application permissions and transitions:
+  - `src/web/apps/applications/views.py`
+  - `src/web/apps/applications/transitions.py`
+  - `src/web/apps/applications/tests_transitions.py`
+- Account / operations endpoints:
+  - `src/web/apps/account/views.py`
+  - `src/web/apps/account/tests.py`
+  - `src/web/apps/imports/views.py`
+  - `src/web/apps/imports/tests.py`
+  - `src/web/apps/recs/views.py`
+  - `src/web/apps/recs/tests.py`

--- a/src/web/apps/account/permissions.py
+++ b/src/web/apps/account/permissions.py
@@ -1,6 +1,11 @@
+import logging
+
 from apps.users.models import UserRole
 from django.core.exceptions import ObjectDoesNotExist
+from rest_framework import permissions
 from rest_framework.exceptions import PermissionDenied
+
+logger = logging.getLogger(__name__)
 
 
 def get_user_role(user) -> str | None:
@@ -14,9 +19,16 @@ def get_user_role(user) -> str | None:
         return None
 
 
+def has_any_role(user, *, allowed: set[str], allow_staff: bool = True) -> bool:
+    role = get_user_role(user)
+    if allow_staff and role == "staff":
+        return True
+    return role in allowed
+
+
 def require_roles(user, *, allowed: set[str]) -> str:
     role = get_user_role(user)
-    if role == "staff" or role in allowed:
+    if has_any_role(user, allowed=allowed):
         return role or "staff"
     raise PermissionDenied("You do not have access to this account endpoint.")
 
@@ -31,3 +43,43 @@ def is_customer(user) -> bool:
 
 def is_cpprp(user) -> bool:
     return get_user_role(user) == UserRole.CPPRP
+
+
+def _log_denied_access(request, view) -> None:
+    user = getattr(request, "user", None)
+    logger.warning(
+        "Denied API access: method=%s path=%s view=%s user_id=%s role=%s",
+        request.method,
+        request.path,
+        view.__class__.__name__,
+        getattr(user, "id", None),
+        get_user_role(user),
+    )
+
+
+class RolePermission(permissions.BasePermission):
+    allowed_roles: set[str] = set()
+    message = "You do not have permission to perform this action."
+    log_denied = False
+
+    def has_permission(self, request, view) -> bool:
+        allowed = has_any_role(request.user, allowed=self.allowed_roles)
+        if not allowed and self.log_denied:
+            _log_denied_access(request, view)
+        return allowed
+
+
+class IsStudentOrStaff(RolePermission):
+    allowed_roles = {UserRole.STUDENT}
+    message = "Only students or staff can access this endpoint."
+
+
+class IsCustomerOrStaff(RolePermission):
+    allowed_roles = {UserRole.CUSTOMER}
+    message = "Only customers or staff can access this endpoint."
+
+
+class IsCpprpOrStaff(RolePermission):
+    allowed_roles = {UserRole.CPPRP}
+    message = "Only CPPRP or staff can access this endpoint."
+    log_denied = True

--- a/src/web/apps/account/tests.py
+++ b/src/web/apps/account/tests.py
@@ -171,3 +171,15 @@ def test_cpprp_can_create_deadlines_and_export_projects():
     assert deadline_response.status_code == 201
     assert export_response.status_code == 200
     assert "project_id" in export_response.content.decode("utf-8")
+
+
+def test_student_cannot_access_cpprp_configuration_endpoints():
+    student = _make_user(role=UserRole.STUDENT)
+    client = Client()
+    client.force_login(student)
+
+    deadlines_response = client.get(reverse("account-cpprp-deadlines"))
+    export_response = client.get(reverse("account-cpprp-export-projects"))
+
+    assert deadlines_response.status_code == 403
+    assert export_response.status_code == 403

--- a/src/web/apps/account/views.py
+++ b/src/web/apps/account/views.py
@@ -11,12 +11,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from .models import DeadlineAudience, DocumentTemplate, PlatformDeadline
-from .permissions import (
-    IsCpprpOrStaff,
-    IsCustomerOrStaff,
-    IsStudentOrStaff,
-    get_user_role,
-)
+from .permissions import IsCpprpOrStaff, IsCustomerOrStaff, IsStudentOrStaff, get_user_role
 from .serializers import (
     AccountApplicationSerializer,
     AccountOverviewSerializer,

--- a/src/web/apps/account/views.py
+++ b/src/web/apps/account/views.py
@@ -11,7 +11,12 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from .models import DeadlineAudience, DocumentTemplate, PlatformDeadline
-from .permissions import require_roles
+from .permissions import (
+    IsCpprpOrStaff,
+    IsCustomerOrStaff,
+    IsStudentOrStaff,
+    get_user_role,
+)
 from .serializers import (
     AccountApplicationSerializer,
     AccountOverviewSerializer,
@@ -80,10 +85,10 @@ class AccountMeAPIView(APIView):
 
 
 class StudentOverviewAPIView(APIView):
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [IsStudentOrStaff]
 
     def get(self, request):
-        role = require_roles(request.user, allowed={"student"})
+        role = get_user_role(request.user) or "student"
         profile = _get_profile(request.user)
         applications = (
             Application.objects.select_related("project", "project__epp", "applicant")
@@ -107,10 +112,9 @@ class StudentOverviewAPIView(APIView):
 
 
 class CustomerProjectsAPIView(APIView):
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [IsCustomerOrStaff]
 
     def get(self, request):
-        require_roles(request.user, allowed={"customer"})
         queryset = (
             Project.objects.select_related("epp")
             .filter(owner=request.user)
@@ -126,10 +130,9 @@ class CustomerProjectsAPIView(APIView):
 
 
 class CustomerApplicationsAPIView(APIView):
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [IsCustomerOrStaff]
 
     def get(self, request):
-        require_roles(request.user, allowed={"customer"})
         queryset = (
             Application.objects.select_related("project", "project__epp", "applicant")
             .filter(project__owner=request.user)
@@ -139,10 +142,9 @@ class CustomerApplicationsAPIView(APIView):
 
 
 class CPPRPModerationQueueAPIView(APIView):
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [IsCpprpOrStaff]
 
     def get(self, request):
-        require_roles(request.user, allowed={"cpprp"})
         queryset = (
             Project.objects.select_related("epp", "owner")
             .filter(status=ProjectStatus.ON_MODERATION)
@@ -158,10 +160,9 @@ class CPPRPModerationQueueAPIView(APIView):
 
 
 class CPPRPApplicationsAPIView(APIView):
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [IsCpprpOrStaff]
 
     def get(self, request):
-        require_roles(request.user, allowed={"cpprp"})
         queryset = Application.objects.select_related("project", "project__epp", "applicant")
         totals = {
             ApplicationStatus.SUBMITTED: queryset.filter(
@@ -177,13 +178,12 @@ class CPPRPApplicationsAPIView(APIView):
 
 class PlatformDeadlineListCreateAPIView(generics.ListCreateAPIView):
     serializer_class = PlatformDeadlineSerializer
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [IsCpprpOrStaff]
 
     def get_queryset(self):
         return PlatformDeadline.objects.all()
 
     def create(self, request, *args, **kwargs):
-        require_roles(request.user, allowed={"cpprp"})
         response = super().create(request, *args, **kwargs)
         emit_event(
             event_type="deadline.changed",
@@ -197,21 +197,16 @@ class PlatformDeadlineListCreateAPIView(generics.ListCreateAPIView):
 
 class DocumentTemplateListCreateAPIView(generics.ListCreateAPIView):
     serializer_class = DocumentTemplateSerializer
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [IsCpprpOrStaff]
 
     def get_queryset(self):
         return DocumentTemplate.objects.all()
 
-    def create(self, request, *args, **kwargs):
-        require_roles(request.user, allowed={"cpprp"})
-        return super().create(request, *args, **kwargs)
-
 
 class CPPRPProjectsExportAPIView(APIView):
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [IsCpprpOrStaff]
 
     def get(self, request):
-        require_roles(request.user, allowed={"cpprp"})
         response = HttpResponse(content_type="text/csv")
         response["Content-Disposition"] = 'attachment; filename="projects-export.csv"'
         writer = csv.writer(response)
@@ -244,10 +239,9 @@ class CPPRPProjectsExportAPIView(APIView):
 
 
 class CPPRPApplicationsExportAPIView(APIView):
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [IsCpprpOrStaff]
 
     def get(self, request):
-        require_roles(request.user, allowed={"cpprp"})
         response = HttpResponse(content_type="text/csv")
         response["Content-Disposition"] = 'attachment; filename="applications-export.csv"'
         writer = csv.writer(response)

--- a/src/web/apps/applications/tests_transitions.py
+++ b/src/web/apps/applications/tests_transitions.py
@@ -68,6 +68,32 @@ def test_application_create_rejected_for_non_catalog_project():
     assert "project" in response.json()
 
 
+def test_customer_cannot_create_application():
+    owner = _make_user(role=UserRole.CUSTOMER)
+    customer = _make_user(role=UserRole.CUSTOMER)
+    project = _make_project(owner, status=ProjectStatus.PUBLISHED)
+
+    client = Client()
+    client.force_login(customer)
+    response = client.post(
+        reverse("application-list"),
+        data={"project": project.pk},
+        content_type="application/json",
+    )
+
+    assert response.status_code == 403
+
+
+def test_customer_cannot_list_applications_from_student_endpoint():
+    customer = _make_user(role=UserRole.CUSTOMER)
+    client = Client()
+    client.force_login(customer)
+
+    response = client.get(reverse("application-list"))
+
+    assert response.status_code == 403
+
+
 def test_project_owner_can_accept_application():
     owner = _make_user(role=UserRole.CUSTOMER)
     student = _make_user(role=UserRole.STUDENT)
@@ -117,6 +143,41 @@ def test_application_review_forbidden_for_non_owner():
 
     client = Client()
     client.force_login(outsider)
+    response = client.post(
+        reverse("application-review", kwargs={"pk": application.pk}),
+        data={"decision": "accept"},
+        content_type="application/json",
+    )
+
+    assert response.status_code == 403
+
+
+def test_student_owner_cannot_review_application():
+    owner = _make_user(role=UserRole.STUDENT)
+    student = _make_user(role=UserRole.STUDENT)
+    project = _make_project(owner, status=ProjectStatus.PUBLISHED)
+    application = _make_application(project, student)
+
+    client = Client()
+    client.force_login(owner)
+    response = client.post(
+        reverse("application-review", kwargs={"pk": application.pk}),
+        data={"decision": "accept"},
+        content_type="application/json",
+    )
+
+    assert response.status_code == 403
+
+
+def test_cpprp_cannot_review_application():
+    owner = _make_user(role=UserRole.CUSTOMER)
+    cpprp = _make_user(role=UserRole.CPPRP)
+    student = _make_user(role=UserRole.STUDENT)
+    project = _make_project(owner, status=ProjectStatus.PUBLISHED)
+    application = _make_application(project, student)
+
+    client = Client()
+    client.force_login(cpprp)
     response = client.post(
         reverse("application-review", kwargs={"pk": application.pk}),
         data={"decision": "accept"},

--- a/src/web/apps/applications/transitions.py
+++ b/src/web/apps/applications/transitions.py
@@ -1,4 +1,6 @@
+from apps.account.permissions import has_any_role
 from apps.projects.transitions import recalculate_project_staffing
+from apps.users.models import UserRole
 from django.utils import timezone
 from rest_framework.exceptions import PermissionDenied, ValidationError
 
@@ -10,7 +12,9 @@ def _can_review_application(actor, application: Application) -> bool:
         return False
     if actor.is_staff:
         return True
-    return application.project.owner_id == actor.id
+    return application.project.owner_id == actor.id and has_any_role(
+        actor, allowed={UserRole.CUSTOMER}, allow_staff=False
+    )
 
 
 def review_application(

--- a/src/web/apps/applications/views.py
+++ b/src/web/apps/applications/views.py
@@ -1,6 +1,7 @@
+from apps.account.permissions import IsCustomerOrStaff, IsStudentOrStaff
 from apps.outbox.services import emit_event
 from apps.projects.models import ProjectStatus
-from rest_framework import generics, permissions
+from rest_framework import generics
 from rest_framework import serializers as drf_serializers
 from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
@@ -13,7 +14,9 @@ from .transitions import review_application
 
 class ApplicationListCreateAPIView(generics.ListCreateAPIView):
     serializer_class = ApplicationSerializer
-    permission_classes = [permissions.IsAuthenticated]
+
+    def get_permissions(self):
+        return [IsStudentOrStaff()]
 
     def get_queryset(self):
         queryset = Application.objects.select_related("project", "applicant")
@@ -54,7 +57,7 @@ class ApplicationListCreateAPIView(generics.ListCreateAPIView):
 
 class ApplicationRetrieveUpdateDestroyAPIView(generics.RetrieveUpdateDestroyAPIView):
     serializer_class = ApplicationSerializer
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [IsStudentOrStaff]
     lookup_field = "pk"
 
     def get_queryset(self):
@@ -71,7 +74,7 @@ class ApplicationReviewInputSerializer(drf_serializers.Serializer):
 
 
 class ApplicationReviewAPIView(APIView):
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [IsCustomerOrStaff]
 
     def post(self, request, pk: int):
         payload = ApplicationReviewInputSerializer(data=request.data)

--- a/src/web/apps/imports/tests.py
+++ b/src/web/apps/imports/tests.py
@@ -21,6 +21,15 @@ def _make_cpprp():
     return user
 
 
+def _make_student():
+    user = get_user_model().objects.create_user(
+        username=f"student-import-{uuid4().hex[:8]}",
+        password="pass123456",
+    )
+    UserProfile.objects.create(user=user, role=UserRole.STUDENT)
+    return user
+
+
 def test_cpprp_can_trigger_import_and_receive_stats(tmp_path):
     path = tmp_path / "EPP.xlsx"
     payload = _sample_mapping()
@@ -35,3 +44,12 @@ def test_cpprp_can_trigger_import_and_receive_stats(tmp_path):
     assert response.json()["status"] == "completed"
     stats = response.json()["stats"]
     assert stats["projects_created"] + stats["projects_updated"] >= 1
+
+
+def test_student_cannot_list_import_runs():
+    client = Client()
+    client.force_login(_make_student())
+
+    response = client.get(reverse("api-v1-import-epp"))
+
+    assert response.status_code == 403

--- a/src/web/apps/imports/views.py
+++ b/src/web/apps/imports/views.py
@@ -1,11 +1,11 @@
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 
-from apps.account.permissions import require_roles
+from apps.account.permissions import IsCpprpOrStaff
 from apps.outbox.services import emit_event
 from apps.projects.importers import default_epp_xlsx_path, import_epp_xlsx
 from django.utils import timezone
-from rest_framework import generics, permissions
+from rest_framework import generics
 from rest_framework.parsers import FormParser, MultiPartParser
 from rest_framework.response import Response
 
@@ -15,14 +15,13 @@ from .serializers import ImportRunSerializer
 
 class ImportRunListCreateAPIView(generics.ListCreateAPIView):
     serializer_class = ImportRunSerializer
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [IsCpprpOrStaff]
     parser_classes = [MultiPartParser, FormParser]
 
     def get_queryset(self):
         return ImportRun.objects.all()
 
     def create(self, request, *args, **kwargs):
-        require_roles(request.user, allowed={"cpprp"})
         upload = request.FILES.get("file")
         import_run = ImportRun.objects.create(
             source="xlsx",

--- a/src/web/apps/projects/tests.py
+++ b/src/web/apps/projects/tests.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 from uuid import uuid4
 
 from apps.projects.models import Project, ProjectSourceType, ProjectStatus
+from apps.users.models import UserProfile, UserRole
 from django.contrib.auth import get_user_model
 from django.db import connection
 from django.test import Client
@@ -19,9 +20,16 @@ def test_project_defaults():
     assert project.tech_tags == []
 
 
-def _make_user():
+def _make_user(*, role: str | None = None, is_staff: bool = False):
     username = f"owner-{uuid4().hex[:8]}"
-    return get_user_model().objects.create_user(username=username, password="test-pass-123")
+    user = get_user_model().objects.create_user(
+        username=username,
+        password="test-pass-123",
+        is_staff=is_staff,
+    )
+    if role is not None:
+        UserProfile.objects.create(user=user, role=role)
+    return user
 
 
 def _title(prefix: str) -> str:
@@ -29,7 +37,7 @@ def _title(prefix: str) -> str:
 
 
 def test_create_project_defaults_extra_data_when_missing():
-    user = _make_user()
+    user = _make_user(role=UserRole.CUSTOMER)
     client = Client()
     client.force_login(user)
 
@@ -46,7 +54,7 @@ def test_create_project_defaults_extra_data_when_missing():
 
 
 def test_create_project_normalizes_null_extra_data():
-    user = _make_user()
+    user = _make_user(role=UserRole.CUSTOMER)
     client = Client()
     client.force_login(user)
 
@@ -63,7 +71,7 @@ def test_create_project_normalizes_null_extra_data():
 
 
 def test_create_project_normalizes_null_tech_tags():
-    user = _make_user()
+    user = _make_user(role=UserRole.CUSTOMER)
     client = Client()
     client.force_login(user)
 
@@ -77,6 +85,35 @@ def test_create_project_normalizes_null_tech_tags():
     project = Project.objects.get(pk=response.json()["pk"])
     assert project.tech_tags == []
     assert response.json()["tech_tags"] == []
+
+
+def test_student_cannot_create_project():
+    student = _make_user(role=UserRole.STUDENT)
+    client = Client()
+    client.force_login(student)
+
+    response = client.post(
+        reverse("api-v1-project-list"),
+        data=json.dumps({"title": _title("Student project")}),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 403
+
+
+def test_cpprp_cannot_update_project_even_if_owner():
+    cpprp = _make_user(role=UserRole.CPPRP)
+    project = _make_project(title=_title("CPPRP owned"), owner=cpprp, status=ProjectStatus.DRAFT)
+    client = Client()
+    client.force_login(cpprp)
+
+    response = client.patch(
+        reverse("api-v1-project-detail", kwargs={"pk": project.pk}),
+        data={"title": _title("Renamed by cpprp")},
+        content_type="application/json",
+    )
+
+    assert response.status_code == 403
 
 
 def _make_project(

--- a/src/web/apps/projects/tests_transitions.py
+++ b/src/web/apps/projects/tests_transitions.py
@@ -61,6 +61,17 @@ def test_project_submit_requires_owner_or_staff():
     assert response.status_code == 403
 
 
+def test_student_owner_cannot_submit_project_for_moderation():
+    owner = _make_user(role=UserRole.STUDENT)
+    project = _make_project(owner, status=ProjectStatus.DRAFT)
+    client = Client()
+    client.force_login(owner)
+
+    response = client.post(reverse("api-v1-project-submit", kwargs={"pk": project.pk}))
+
+    assert response.status_code == 403
+
+
 def test_cpprp_can_approve_project_on_moderation():
     owner = _make_user(role=UserRole.CUSTOMER)
     cpprp = _make_user(role=UserRole.CPPRP)
@@ -78,6 +89,22 @@ def test_cpprp_can_approve_project_on_moderation():
     project.refresh_from_db()
     assert project.status == ProjectStatus.PUBLISHED
     assert project.moderated_by_id == cpprp.id
+
+
+def test_customer_cannot_moderate_project():
+    owner = _make_user(role=UserRole.CUSTOMER)
+    customer = _make_user(role=UserRole.CUSTOMER)
+    project = _make_project(owner, status=ProjectStatus.ON_MODERATION)
+    client = Client()
+    client.force_login(customer)
+
+    response = client.post(
+        reverse("api-v1-project-moderate", kwargs={"pk": project.pk}),
+        data={"decision": "approve"},
+        content_type="application/json",
+    )
+
+    assert response.status_code == 403
 
 
 def test_project_reject_requires_comment():

--- a/src/web/apps/projects/transitions.py
+++ b/src/web/apps/projects/transitions.py
@@ -1,3 +1,4 @@
+from apps.account.permissions import has_any_role
 from apps.users.models import UserRole
 from django.core.exceptions import ObjectDoesNotExist
 from django.utils import timezone
@@ -23,8 +24,12 @@ def _is_cpprp_or_staff(actor) -> bool:
 
 
 def submit_project_for_moderation(project: Project, actor) -> Project:
-    if not (_is_project_owner(actor, project) or getattr(actor, "is_staff", False)):
-        raise PermissionDenied("Only the project owner or staff can submit this project.")
+    if getattr(actor, "is_staff", False):
+        pass
+    elif not _is_project_owner(actor, project) or not has_any_role(
+        actor, allowed={UserRole.CUSTOMER}, allow_staff=False
+    ):
+        raise PermissionDenied("Only the customer project owner or staff can submit this project.")
 
     if project.status not in {
         ProjectStatus.DRAFT,

--- a/src/web/apps/projects/views.py
+++ b/src/web/apps/projects/views.py
@@ -1,3 +1,4 @@
+from apps.account.permissions import IsCpprpOrStaff, IsCustomerOrStaff
 from apps.outbox.services import emit_event
 from django.db.models import Count, Q
 from django.shortcuts import get_object_or_404
@@ -179,6 +180,11 @@ class ProjectListCreateAPIView(generics.ListCreateAPIView):
     pagination_class = ProjectListPagination
     ordering_fields = ("created_at", "updated_at")
 
+    def get_permissions(self):
+        if self.request.method == "POST":
+            return [IsCustomerOrStaff()]
+        return [permissions.AllowAny()]
+
     def get_queryset(self):
         queryset = _base_queryset(self.request.user)
         return _apply_project_filters(queryset, self.request.query_params)
@@ -202,6 +208,7 @@ class ProjectDetailAPIView(generics.RetrieveAPIView):
         applications_count=Count("applications")
     )
     serializer_class = PrimaryProjectSerializer
+    permission_classes = [permissions.AllowAny]
 
     def get_queryset(self):
         user = self.request.user
@@ -219,6 +226,7 @@ class ProjectUpdateAPIView(generics.UpdateAPIView):
     queryset = Project.objects.select_related("owner", "epp")
     serializer_class = PrimaryProjectSerializer
     lookup_field = "pk"
+    permission_classes = [IsCustomerOrStaff]
 
     def get_queryset(self):
         user = self.request.user
@@ -234,6 +242,7 @@ class ProjectDestroyAPIView(generics.DestroyAPIView):
     queryset = Project.objects.select_related("owner", "epp")
     serializer_class = PrimaryProjectSerializer
     lookup_field = "pk"
+    permission_classes = [IsCustomerOrStaff]
 
     def get_queryset(self):
         user = self.request.user
@@ -251,6 +260,11 @@ class ProjectRetrieveUpdateDestroyAPIView(generics.RetrieveUpdateDestroyAPIView)
     )
     serializer_class = PrimaryProjectSerializer
     lookup_field = "pk"
+
+    def get_permissions(self):
+        if self.request.method in permissions.SAFE_METHODS:
+            return [permissions.AllowAny()]
+        return [IsCustomerOrStaff()]
 
     def get_queryset(self):
         user = self.request.user
@@ -285,7 +299,7 @@ class ProjectModerationInputSerializer(serializers.Serializer):
 
 
 class ProjectSubmitForModerationAPIView(APIView):
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [IsCustomerOrStaff]
 
     def post(self, request, pk: int):
         project = get_object_or_404(Project.objects.select_related("owner", "epp"), pk=pk)
@@ -302,7 +316,7 @@ class ProjectSubmitForModerationAPIView(APIView):
 
 
 class ProjectModerationAPIView(APIView):
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [IsCpprpOrStaff]
 
     def post(self, request, pk: int):
         payload = ProjectModerationInputSerializer(data=request.data)

--- a/src/web/apps/recs/tests.py
+++ b/src/web/apps/recs/tests.py
@@ -20,6 +20,15 @@ def _make_student(*, interests=None):
     return user
 
 
+def _make_cpprp():
+    user = get_user_model().objects.create_user(
+        username=f"cpprp-recs-{uuid4().hex[:8]}",
+        password="pass123456",
+    )
+    UserProfile.objects.create(user=user, role=UserRole.CPPRP)
+    return user
+
+
 def test_recommendations_endpoint_returns_local_fallback_results():
     token = f"focus-{uuid4().hex[:8]}"
     Project.objects.create(
@@ -53,3 +62,26 @@ def test_recs_search_endpoint_returns_ranked_projects():
 
     assert response.status_code == 200
     assert response.json()["items"][0]["project"]["title"] == "Graph analytics"
+
+
+def test_only_cpprp_can_request_reindex():
+    client = Client()
+    client.force_login(_make_student())
+
+    denied = client.post(
+        reverse("api-v1-recs-reindex"),
+        data={"reason": "student"},
+        content_type="application/json",
+    )
+
+    assert denied.status_code == 403
+
+    client.force_login(_make_cpprp())
+    allowed = client.post(
+        reverse("api-v1-recs-reindex"),
+        data={"reason": "cpprp"},
+        content_type="application/json",
+    )
+
+    assert allowed.status_code == 200
+    assert allowed.json()["status"] == "accepted"

--- a/src/web/apps/recs/views.py
+++ b/src/web/apps/recs/views.py
@@ -5,10 +5,7 @@ from rest_framework import permissions
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from .serializers import (
-    RecommendationRequestSerializer,
-    SearchRequestSerializer,
-)
+from .serializers import RecommendationRequestSerializer, SearchRequestSerializer
 from .services import recommend_projects, search_projects
 
 

--- a/src/web/apps/recs/views.py
+++ b/src/web/apps/recs/views.py
@@ -1,4 +1,4 @@
-from apps.account.permissions import require_roles
+from apps.account.permissions import IsCpprpOrStaff
 from apps.outbox.services import emit_event
 from apps.users.models import UserProfile
 from rest_framework import permissions
@@ -53,10 +53,9 @@ class RecommendationListAPIView(APIView):
 
 
 class RecommendationReindexAPIView(APIView):
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [IsCpprpOrStaff]
 
     def post(self, request):
-        require_roles(request.user, allowed={"cpprp"})
         emit_event(
             event_type="recs.reindex_requested",
             aggregate_type="recs",


### PR DESCRIPTION
## Контекст
Добавлены API для кандидатов на релиз и контракты, а также реализована матрица разрешений API и контроль доступа на основе ролей для различных конечных точек.

## Что сделано
- Добавлены заглушки для ML шлюза и графовой базы.
- Реализована сериализация для событий и импортов.
- Обновлены конфигурации приложений и добавлены новые модели.

## Как проверял(а)
- [x] `./scripts/uv-linters.sh`

