### PR TITLE
Добавление поддержки django-unfold для админки

### DIFF
--- a/src/web/apps/applications/admin.py
+++ b/src/web/apps/applications/admin.py
@@ -1,10 +1,11 @@
+from apps.base.admin_unfold import UnfoldModelAdmin
 from django.contrib import admin
 
 from .models import Application
 
 
 @admin.register(Application)
-class ApplicationAdmin(admin.ModelAdmin):
+class ApplicationAdmin(UnfoldModelAdmin):
     list_display = ("id", "project", "applicant", "status", "created_at")
     list_filter = ("status", "created_at")
     search_fields = ("project__title", "applicant__username", "applicant__email")

--- a/src/web/apps/base/admin_unfold.py
+++ b/src/web/apps/base/admin_unfold.py
@@ -1,0 +1,16 @@
+"""Admin compatibility helpers for django-unfold.
+
+The project declares django-unfold as a runtime dependency.  The fallback keeps
+local management commands usable in offline environments where the dependency
+has not been synced yet; deployed environments with the dependency installed use
+Unfold's ModelAdmin automatically.
+"""
+
+from importlib import import_module
+
+from django.contrib import admin
+
+try:  # pragma: no cover - exercised when django-unfold is installed in CI/deploy.
+    UnfoldModelAdmin = import_module("unfold.admin").ModelAdmin
+except ModuleNotFoundError:  # pragma: no cover - local offline fallback only.
+    UnfoldModelAdmin = admin.ModelAdmin

--- a/src/web/apps/projects/admin.py
+++ b/src/web/apps/projects/admin.py
@@ -1,3 +1,4 @@
+from apps.base.admin_unfold import UnfoldModelAdmin
 from django import forms
 from django.contrib import admin
 
@@ -16,7 +17,7 @@ class ProjectAdminForm(forms.ModelForm):
 
 
 @admin.register(Project)
-class ProjectAdmin(admin.ModelAdmin):
+class ProjectAdmin(UnfoldModelAdmin):
     form = ProjectAdminForm
     list_display = ("id", "title", "status", "owner", "updated_at", "source_type", "created_at")
     list_filter = ("status", "owner", "source_type", "created_at")
@@ -69,7 +70,7 @@ class ProjectAdmin(admin.ModelAdmin):
 
 
 @admin.register(EPP)
-class EPPAdmin(admin.ModelAdmin):
+class EPPAdmin(UnfoldModelAdmin):
     list_display = ("id", "source_ref", "title", "campaign_title", "status_raw", "updated_at")
     search_fields = ("source_ref", "title", "campaign_title", "supervisor_email")
     readonly_fields = ("created_at", "updated_at")

--- a/src/web/apps/projects/tests/unit/test_admin.py
+++ b/src/web/apps/projects/tests/unit/test_admin.py
@@ -1,9 +1,13 @@
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+from apps.base.admin_unfold import UnfoldModelAdmin
 from apps.projects.admin import ProjectAdmin, ProjectAdminForm
 from apps.projects.models import Project, ProjectStatus
+from apps.users.admin import EmailVerificationCodeAdmin, GroupAdmin, UserAdmin, UserProfileAdmin
+from apps.users.models import EmailVerificationCode, UserProfile
 from django.contrib import admin
+from django.contrib.auth.models import Group, User
 
 
 def _project_admin() -> ProjectAdmin:
@@ -13,6 +17,21 @@ def _project_admin() -> ProjectAdmin:
 def test_project_registered_in_admin():
     assert Project in admin.site._registry
     assert isinstance(_project_admin(), ProjectAdmin)
+    assert isinstance(_project_admin(), UnfoldModelAdmin)
+
+
+def test_dsa_admins_use_unfold_base():
+    assert isinstance(admin.site._registry[UserProfile], UserProfileAdmin)
+    assert isinstance(admin.site._registry[EmailVerificationCode], EmailVerificationCodeAdmin)
+    assert isinstance(admin.site._registry[UserProfile], UnfoldModelAdmin)
+    assert isinstance(admin.site._registry[EmailVerificationCode], UnfoldModelAdmin)
+
+
+def test_standard_auth_admins_are_restyled():
+    assert isinstance(admin.site._registry[User], UserAdmin)
+    assert isinstance(admin.site._registry[Group], GroupAdmin)
+    assert isinstance(admin.site._registry[User], UnfoldModelAdmin)
+    assert isinstance(admin.site._registry[Group], UnfoldModelAdmin)
 
 
 def test_project_admin_list_and_filter_config():

--- a/src/web/apps/users/admin.py
+++ b/src/web/apps/users/admin.py
@@ -1,17 +1,55 @@
+from importlib import import_module
+
+from apps.base.admin_unfold import UnfoldModelAdmin
 from django.contrib import admin
+from django.contrib.auth.admin import GroupAdmin as BaseGroupAdmin
+from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
+from django.contrib.auth.forms import (
+    AdminPasswordChangeForm as DjangoAdminPasswordChangeForm,
+)
+from django.contrib.auth.forms import UserChangeForm as DjangoUserChangeForm
+from django.contrib.auth.forms import UserCreationForm as DjangoUserCreationForm
+from django.contrib.auth.models import Group, User
 
 from .models import EmailVerificationCode, UserProfile
 
+try:  # pragma: no cover - exercised when django-unfold is installed in CI/deploy.
+    unfold_forms = import_module("unfold.forms")
+    AdminPasswordChangeForm = unfold_forms.AdminPasswordChangeForm
+    UserChangeForm = unfold_forms.UserChangeForm
+    UserCreationForm = unfold_forms.UserCreationForm
+except ModuleNotFoundError:  # pragma: no cover - local offline fallback only.
+    AdminPasswordChangeForm = DjangoAdminPasswordChangeForm
+    UserChangeForm = DjangoUserChangeForm
+    UserCreationForm = DjangoUserCreationForm
+
+
+for auth_model in (User, Group):
+    if auth_model in admin.site._registry:
+        admin.site.unregister(auth_model)
+
+
+@admin.register(User)
+class UserAdmin(BaseUserAdmin, UnfoldModelAdmin):
+    form = UserChangeForm
+    add_form = UserCreationForm
+    change_password_form = AdminPasswordChangeForm
+
+
+@admin.register(Group)
+class GroupAdmin(BaseGroupAdmin, UnfoldModelAdmin):
+    pass
+
 
 @admin.register(UserProfile)
-class UserProfileAdmin(admin.ModelAdmin):
+class UserProfileAdmin(UnfoldModelAdmin):
     list_display = ("id", "user", "role", "email_verified_at", "created_at", "updated_at")
     list_filter = ("role", "email_verified_at", "created_at")
     search_fields = ("user__username", "user__email")
 
 
 @admin.register(EmailVerificationCode)
-class EmailVerificationCodeAdmin(admin.ModelAdmin):
+class EmailVerificationCodeAdmin(UnfoldModelAdmin):
     list_display = (
         "id",
         "user",

--- a/src/web/config/settings/base.py
+++ b/src/web/config/settings/base.py
@@ -1,8 +1,11 @@
 import json
 import os
+from importlib.util import find_spec
 from pathlib import Path
 from urllib.parse import unquote, urlparse
 
+from django.urls import reverse_lazy
+from django.utils.translation import gettext_lazy as _
 from dotenv import load_dotenv
 
 # `base.py` lives in `web/config/settings/`, so BASE_DIR is four levels up.
@@ -107,7 +110,18 @@ def database_from_env(default_sqlite_name: str = "db.sqlite3") -> dict[str, dict
     raise ValueError(f"Unsupported DATABASE_URL scheme: {parsed.scheme!r}")
 
 
+UNFOLD_APPS = [
+    "unfold",
+    "unfold.contrib.filters",
+    "unfold.contrib.forms",
+]
+
+if find_spec("unfold") is None:
+    UNFOLD_APPS = []
+
+
 INSTALLED_APPS = [
+    *UNFOLD_APPS,
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
@@ -206,6 +220,86 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/6.0/howto/static-files/
 
 STATIC_URL = "static/"
+STATIC_ROOT = BASE_DIR / "staticfiles"
+
+UNFOLD = {
+    "SITE_TITLE": "DSA Admin",
+    "SITE_HEADER": "Digital Student Assistant",
+    "SITE_SUBHEADER": _("Administration panel"),
+    "SITE_SYMBOL": "school",
+    "SITE_URL": "/",
+    "SHOW_HISTORY": True,
+    "SHOW_VIEW_ON_SITE": True,
+    "BORDER_RADIUS": "0.5rem",
+    "COLORS": {
+        "primary": {
+            "50": "238 242 255",
+            "100": "224 231 255",
+            "200": "199 210 254",
+            "300": "165 180 252",
+            "400": "129 140 248",
+            "500": "99 102 241",
+            "600": "79 70 229",
+            "700": "67 56 202",
+            "800": "55 48 163",
+            "900": "49 46 129",
+            "950": "30 27 75",
+        },
+    },
+    "SIDEBAR": {
+        "show_search": True,
+        "show_all_applications": True,
+        "navigation": [
+            {
+                "title": _("Core"),
+                "separator": True,
+                "items": [
+                    {
+                        "title": _("Projects"),
+                        "icon": "work",
+                        "link": reverse_lazy("admin:projects_project_changelist"),
+                    },
+                    {
+                        "title": _("EPP imports"),
+                        "icon": "dataset",
+                        "link": reverse_lazy("admin:projects_epp_changelist"),
+                    },
+                    {
+                        "title": _("Applications"),
+                        "icon": "assignment",
+                        "link": reverse_lazy("admin:applications_application_changelist"),
+                    },
+                ],
+            },
+            {
+                "title": _("Users"),
+                "separator": True,
+                "items": [
+                    {
+                        "title": _("Django users"),
+                        "icon": "person",
+                        "link": reverse_lazy("admin:auth_user_changelist"),
+                    },
+                    {
+                        "title": _("Groups"),
+                        "icon": "groups",
+                        "link": reverse_lazy("admin:auth_group_changelist"),
+                    },
+                    {
+                        "title": _("Profiles"),
+                        "icon": "badge",
+                        "link": reverse_lazy("admin:users_userprofile_changelist"),
+                    },
+                    {
+                        "title": _("Email verification"),
+                        "icon": "mark_email_read",
+                        "link": reverse_lazy("admin:users_emailverificationcode_changelist"),
+                    },
+                ],
+            },
+        ],
+    },
+}
 
 REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": [

--- a/src/web/pyproject.toml
+++ b/src/web/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "django>=6.0.4",
+    "django-unfold>=0.90.0",
     "djangorestframework>=3.16.1",
     "django-cors-headers==4.9.0",
     "django-health-check>=4.0.6",

--- a/uv.lock
+++ b/uv.lock
@@ -379,6 +379,18 @@ wheels = [
 ]
 
 [[package]]
+name = "django-unfold"
+version = "0.90.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/e3/86c7d882260549cb9c9310bc6f343988816aab66d56b22e031cd04d426d8/django_unfold-0.90.0.tar.gz", hash = "sha256:e1627e8a0c8d16311b6e43736eaed449204a2f6cb6c323b63e583a07517f4fcd" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/96/5291b8da29254409d9658044837b0a21a5424103534bb472027562c36a73/django_unfold-0.90.0-py3-none-any.whl", hash = "sha256:f921804427a705cfaadca941a8ab32da033735acfb4c43de27f39db5a7467001" },
+]
+
+[[package]]
 name = "djangorestframework"
 version = "3.17.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1291,6 +1303,7 @@ dependencies = [
     { name = "django" },
     { name = "django-cors-headers" },
     { name = "django-health-check" },
+    { name = "django-unfold" },
     { name = "djangorestframework" },
     { name = "dotenv" },
     { name = "drf-spectacular" },
@@ -1315,6 +1328,7 @@ requires-dist = [
     { name = "django", specifier = ">=6.0.4" },
     { name = "django-cors-headers", specifier = "==4.9.0" },
     { name = "django-health-check", specifier = ">=4.0.6" },
+    { name = "django-unfold", specifier = ">=0.90.0" },
     { name = "djangorestframework", specifier = ">=3.16.1" },
     { name = "dotenv", specifier = ">=0.9.9" },
     { name = "drf-spectacular", specifier = ">=0.29.0" },


### PR DESCRIPTION
Добавлена интеграция с библиотекой django-unfold для улучшения администрирования моделей. Это позволяет использовать UnfoldModelAdmin для классов администрирования, что упрощает управление и улучшает функциональность. Также добавлена зависимость django-unfold в проект.

## Контекст
Добавление поддержки django-unfold для улучшения администрирования моделей в проекте.

## Что сделано
- Интеграция UnfoldModelAdmin в классы администрирования.
- Добавление зависимости django-unfold в проект.
