### PR TITLE
Potential fix for code scanning alert no. 6: DOM text reinterpreted as HTML

### DIFF
--- a/src/web/templates/frontend/project_form.html
+++ b/src/web/templates/frontend/project_form.html
@@ -199,15 +199,22 @@
     tags.forEach(function(tag, i) {
       var chip = document.createElement('span');
       chip.style.cssText = 'display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:6px;font-size:0.75rem;font-weight:500;background:#eff6ff;color:#1d4ed8;border:1px solid #bfdbfe;';
-      chip.innerHTML =
-        tag +
-        '<button type="button" data-i="' + i + '" ' +
-        'style="background:none;border:none;cursor:pointer;color:#60a5fa;font-size:14px;line-height:1;padding:0 0 0 2px;" ' +
-        'title="Удалить">×</button>';
-      chip.querySelector('button').addEventListener('click', function() {
+
+      var tagText = document.createTextNode(tag);
+      chip.appendChild(tagText);
+
+      var removeBtn = document.createElement('button');
+      removeBtn.type = 'button';
+      removeBtn.dataset.i = String(i);
+      removeBtn.style.cssText = 'background:none;border:none;cursor:pointer;color:#60a5fa;font-size:14px;line-height:1;padding:0 0 0 2px;';
+      removeBtn.title = 'Удалить';
+      removeBtn.textContent = '×';
+      removeBtn.addEventListener('click', function() {
         tags.splice(parseInt(this.dataset.i), 1);
         render(); sync();
       });
+      chip.appendChild(removeBtn);
+
       chipsEl.appendChild(chip);
     });
   }


### PR DESCRIPTION
Potential fix for [https://github.com/krevetka-is-afk/Digital-Student-Assistant/security/code-scanning/6](https://github.com/krevetka-is-afk/Digital-Student-Assistant/security/code-scanning/6)

General fix: never concatenate untrusted text into `innerHTML`. Build DOM nodes explicitly and place user data with `textContent` so it is treated as plain text, not HTML.

Best fix here (single change covers all 4 variants): update `render()` in `src/web/templates/frontend/project_form.html` where chips are created. Replace the `chip.innerHTML = ...` block with explicit creation of a text node (for `tag`) and a `button` element configured via properties/attributes. Keep all existing behavior/styles intact, including the remove button, `data-i`, title, and click handler. No new imports/dependencies are needed since this is plain browser DOM API.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
