### PR TITLE
Potential fix for code scanning alert no. 5: DOM text reinterpreted as HTML

### DIFF
--- a/src/web/templates/frontend/profile.html
+++ b/src/web/templates/frontend/profile.html
@@ -386,7 +386,17 @@ function renderInterestChips() {
   _interests.forEach(function(tag, idx) {
     var chip = document.createElement('span');
     chip.style.cssText = 'display:inline-flex;align-items:center;gap:4px;padding:2px 8px 2px 10px;background:#eff6ff;color:#1d4ed8;border-radius:9999px;font-size:0.75rem;font-weight:500;white-space:nowrap;';
-    chip.innerHTML = tag + '<button type="button" onclick="removeInterestTag(' + idx + ')" style="color:#93c5fd;font-size:0.9rem;line-height:1;background:none;border:none;cursor:pointer;padding:0;">×</button>';
+    chip.appendChild(document.createTextNode(tag));
+
+    var removeBtn = document.createElement('button');
+    removeBtn.type = 'button';
+    removeBtn.textContent = '×';
+    removeBtn.style.cssText = 'color:#93c5fd;font-size:0.9rem;line-height:1;background:none;border:none;cursor:pointer;padding:0;';
+    removeBtn.addEventListener('click', function() {
+      removeInterestTag(idx);
+    });
+
+    chip.appendChild(removeBtn);
     container.appendChild(chip);
   });
   syncInterests();


### PR DESCRIPTION
Potential fix for [https://github.com/krevetka-is-afk/Digital-Student-Assistant/security/code-scanning/5](https://github.com/krevetka-is-afk/Digital-Student-Assistant/security/code-scanning/5)

General fix: avoid `innerHTML` when rendering any data that could be user-controlled. Build DOM nodes with `createElement`, assign user data via `textContent`, and attach events via `addEventListener` instead of inline `onclick`.

Best fix in `src/web/templates/frontend/profile.html` (inside `renderInterestChips`, around lines 387–390):
- Keep creating the `span` chip.
- Replace `chip.innerHTML = ...` with:
  - `chip.appendChild(document.createTextNode(tag))` (or a text span with `textContent = tag`)
  - create a `<button>` element programmatically
  - set button attributes/styles via properties
  - bind click handler with `addEventListener('click', ...)` calling `removeInterestTag(idx)`
  - append button to `chip`
- This preserves UI and functionality while removing HTML interpretation of `tag`.

No new imports or external libraries are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
