### PR TITLE
Potential fix for code scanning alert no. 8: URL redirection from remote source

### DIFF
--- a/src/web/apps/frontend/views/auth.py
+++ b/src/web/apps/frontend/views/auth.py
@@ -241,6 +241,9 @@ def resend_email_code_view(request):
     email = request.POST.get("email", "").strip().lower()
     next_url = request.POST.get("next", "").strip()
 
+    safe_next_url = _safe_redirect_target(request, next_url)
+    safe_email = email if _check_email_fmt(email) else ""
+
     result = resend_signup_code(email)
     if result.retry_after_seconds:
         messages.info(
@@ -250,7 +253,7 @@ def resend_email_code_view(request):
         )
     else:
         messages.info(request, result.message)
-    return redirect(_verification_redirect_url(email, next_url))
+    return redirect(_verification_redirect_url(safe_email, safe_next_url))
 
 
 @require_POST


### PR DESCRIPTION
Potential fix for [https://github.com/krevetka-is-afk/Digital-Student-Assistant/security/code-scanning/8](https://github.com/krevetka-is-afk/Digital-Student-Assistant/security/code-scanning/8)

General fix: do not pass raw user input into redirect targets, even as query parameters, without validation/normalization. For `next`, allow only safe local paths using the existing `_safe_redirect_target` helper. For `email`, normalize and validate format before reusing it in redirect query parameters.

Best fix in this file:
- In `resend_email_code_view` (around lines 241–253), sanitize `next_url` with `_safe_redirect_target(request, next_url)` before calling `_verification_redirect_url`.
- Validate `email` with existing `_check_email_fmt`; if invalid, pass an empty string to avoid propagating arbitrary user input.
- Keep existing behavior/messages unchanged otherwise.

No new imports are needed because `_safe_redirect_target` and `_check_email_fmt` already exist in this file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
